### PR TITLE
Adds a basic route structure with static routes

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "lint": "eslint --ext .js,.vue src test/unit/specs"
   },
   "dependencies": {
-    "vue": "^2.1.0"
+    "vue": "^2.1.9",
+    "vue-router": "^2.1.1"
   },
   "devDependencies": {
     "autoprefixer": "^6.4.0",

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,21 +1,13 @@
 <template>
   <div id="app">
     <img src="./assets/logoRadiSaclay.png" width="150">
-    <welcome></welcome>
-    <login></login>
+    <router-view></router-view>
   </div>
 </template>
 
 <script>
-import Welcome from './components/Welcome'
-import Login from './components/Login'
-
 export default {
-  name: 'app',
-  components: {
-    Welcome,
-    Login
-  }
+  name: 'app'
 }
 </script>
 

--- a/src/components/Home.vue
+++ b/src/components/Home.vue
@@ -1,0 +1,17 @@
+<template>
+  <div class="home">
+    <h1>{{ msg }}</h1>
+    <router-link to="/send-notif">Poster une annonce</router-link>
+  </div>
+</template>
+
+<script>
+  export default {
+    name: 'home',
+    data () {
+      return {
+        msg: 'Page perso'
+      }
+    }
+  }
+</script>

--- a/src/components/Login.vue
+++ b/src/components/Login.vue
@@ -2,9 +2,11 @@
   <div class="login">
     <input type="text" name="email" placeholder="adresse e-mail" v-model="userInput.email">
     <input type="password" name="password" placeholder="mot de passe" v-model="userInput.pw">
-    <button v-model="message" v-on:click="checkUser">{{ message }}</button>
-    <p v-if="connected"> connexion réussie </p>
+    <button v-on:click="checkUser">{{ buttonText }}</button>
+    <br>
+    <button v-on:click="sendPassword">mot de passe oublié ?</button>
     <p v-if="!connected && attempted"> identifiants incorrects</p>
+    <p v-if="showLoginDetails">identifiants de test --- email: {{ dataBaseSimulation[0].email }} mdp: {{ dataBaseSimulation[0].pw }}<p>
   </div>
 </template>
 
@@ -13,28 +15,39 @@
     name: 'login',
     data () {
       return {
-        // TODO replace by request to database
-        dataBaseSimulation: [
-          {email: 'radisaclay@ensta.fr', pw: 'radis'}
-        ],
-        message: 'Se connecter',
-        connected: false,
         attempted: false,
+        connected: false,
+        // TODO replace by request to reset password
+        showLoginDetails: false,
+        buttonText: 'Se connecter',
         userInput: {
           email: '',
           pw: ''
-        }
+        },
+
+        // TODO use the remote database
+        dataBaseSimulation: [
+          {email: 'radisaclay@ensta.fr', pw: 'radis'},
+          {email: 'a', pw: ''}
+        ]
       }
     },
     methods: {
+      // TODO replace by query to database
       checkUser: function () {
-        this.attempted = true
+        this.attempted = true // tells if the user as already attempted to connect
         var emailInput = this.userInput.email
         var pwInput = this.userInput.pw
         var filtered = this.dataBaseSimulation.filter(function (e) { return (e.email === emailInput && e.pw === pwInput) })
+        // if login details are valid then go to user home
         if (filtered.length === 1) {
           this.connected = true
+          this.$router.push('/home')
         }
+      },
+      // TODO replace by a method that resets the password
+      sendPassword: function () {
+        this.showLoginDetails = true
       }
     }
   }

--- a/src/components/Sendnotif.vue
+++ b/src/components/Sendnotif.vue
@@ -1,0 +1,17 @@
+<template>
+  <div class="send-notif">
+    <h1>{{ msg }}</h1>
+    <router-link to="/home">Voir mes annonces</router-link>
+  </div>
+</template>
+
+<script>
+  export default {
+    name: 'send-notif',
+    data () {
+      return {
+        msg: 'Envoyer une notification'
+      }
+    }
+  }
+</script>

--- a/src/main.js
+++ b/src/main.js
@@ -1,12 +1,21 @@
 // The Vue build version to load with the `import` command
 // (runtime-only or standalone) has been set in webpack.base.conf with an alias.
 import Vue from 'vue'
-// import VueRouter from 'vue-router'
 import App from './App'
+import VueRouter from 'vue-router'
+import routes from './routes'
 
-/* eslint-disable no-new */
+// initialization of the router
+Vue.use(VueRouter)
+
+const router = new VueRouter({
+  routes: routes.routes
+})
+
+// instantiation of the vue
 new Vue({
   el: '#app',
   template: '<App/>',
-  components: { App }
-})
+  components: { App },
+  router: router
+}).$mount('#app')

--- a/src/routes.js
+++ b/src/routes.js
@@ -1,0 +1,16 @@
+/**
+ * Created by lbertaux on 1/17/17.
+ */
+import Home from './components/Home'
+import Login from './components/Login'
+import Sendnotif from './components/Sendnotif'
+
+const routes = [
+  { path: '/', component: Login },
+  { path: '/home', component: Home },
+  { path: '/send-notif', component: Sendnotif }
+]
+
+export default {
+  routes
+}


### PR DESCRIPTION
This PR proposes a **basic route structure** for the web application: 

![basicroutes](https://cloud.githubusercontent.com/assets/16387779/22030026/b1fda18a-dcdc-11e6-947a-a1ca493ed3c0.gif)

There are currently three routes:

- _/_ for the login page
- _/home_ for the user home (where he will be able to consult his notifications, etc...)
- _/send-notif_ for the user to send a new notification

So far, all the routes are static and do not depend on the user. More routes will be added soon.