### PR TITLE
Adds the menu bar at the top of all pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,8 @@
   <head>
     <meta charset="utf-8">
     <title>radi-web-producer</title>
+    <!--TODO see whether it's relevant-->
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.2.7/semantic.min.css">
   </head>
   <body>
     <div id="app"></div>

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,13 +1,22 @@
 <template>
   <div id="app">
+
+    <!-- TODO: hide the menu bar when in the login page -->
+    <menubar></menubar>
+
     <img src="./assets/logoRadiSaclay.png" width="150">
     <router-view></router-view>
+
   </div>
 </template>
 
 <script>
+import Menubar from './components/home/Menubar'
 export default {
-  name: 'app'
+  name: 'app',
+  components: {
+    Menubar
+  }
 }
 </script>
 

--- a/src/components/Home.vue
+++ b/src/components/Home.vue
@@ -1,7 +1,6 @@
 <template>
   <div class="home">
     <h1>Liste des notifications postées :</h1>
-    <router-link to="/send-notif">Poster une annonce</router-link>
     <notiflist></notiflist>
   </div>
 </template>

--- a/src/components/Sendnotif.vue
+++ b/src/components/Sendnotif.vue
@@ -1,7 +1,6 @@
 <template>
   <div class="send-notif">
     <h1>{{ msg }}</h1>
-    <router-link to="/home">Voir mes annonces</router-link>
   </div>
 </template>
 

--- a/src/components/home/Menubar.vue
+++ b/src/components/home/Menubar.vue
@@ -1,0 +1,16 @@
+<template>
+  <div class="ui fixed inverted menu">
+    <div class="ui container"> <!-- = centered -->
+
+      <router-link to="/home" class="item">Voir mes annonces</router-link>
+      <router-link to="/send-notif" class="item">Poster une annonce</router-link>
+
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'menubar'
+}
+</script>


### PR DESCRIPTION
The menu bar helps to navigate through the pages.
For now it's quite basic.

![menubar](https://cloud.githubusercontent.com/assets/24297016/22122995/405f2418-de8a-11e6-933d-b92edead16df.gif)

Points needing improvements:
- Hide the menu bar when the user is in the login page.
- Highlight the icon with the link for the current page (in bold? Prevent it from being clicked?) .
