### PR TITLE
adds route guards to protect navigation

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -10,6 +10,8 @@ import App from './App'
 import VueRouter from 'vue-router'
 import routes from './routes/routes'
 import VueResource from 'vue-resource'
+import auth from './Auth'
+import settings from './config/settings'
 
 require('!style!css!less!./config/css/semantic.less')
 
@@ -20,6 +22,30 @@ Vue.config.debug = true;
 
 const router = new VueRouter({
   routes: routes.routes
+})
+
+//route protection
+router.beforeEach((to,from,next) => {
+  //check if the user is authenticated
+  auth.checkAuth()
+  //redirect the user to the login route if he wants to navigate without authentification
+  if (to.name != 'login') {
+    if (!auth.user.authenticated) {
+      next({name : 'login'})
+    }
+    else {
+      next()
+    }
+  }
+  //skip the login page if the user is already authenticated
+  else {
+    if (!auth.user.authenticated) {
+      next()
+    }
+    else {
+      next(settings.urls.HOMEPAGE)
+    }
+  }
 })
 
 // instantiation of the vue

--- a/src/routes/routes.js
+++ b/src/routes/routes.js
@@ -6,7 +6,7 @@ import farmhome from './FarmHome.vue'
 import eventhome from './EventHome.vue'
 
 const routes = [
-  { path: '/', component: Login },
+  { path: '/', name: 'login', component: Login },
   { path: '/farmhome', component: farmhome },
   { path: '/eventhome', component: eventhome },
 ]


### PR DESCRIPTION
This small PR aims at preventing the user to access routes without authentification.

If the user did not log in, he can not access the other pages of the app, even if he changes the URL.
(Before this, the user could change the URL and see an empty home, an empty event page etc...).

Added to that, the login page will be skipped if the user has already logged in.

This feature is implemented using the _route guards_ from _vue-router_.