### PR TITLE
Solves the build issue

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -7,7 +7,7 @@ module.exports = {
     index: path.resolve(__dirname, '../dist/index.html'),
     assetsRoot: path.resolve(__dirname, '../dist'),
     assetsSubDirectory: 'static',
-    assetsPublicPath: '/',
+    //assetsPublicPath: '/',
     productionSourceMap: true,
     // Gzip off by default as many popular static hosts such as
     // Surge or Netlify already gzip all static assets for you.


### PR DESCRIPTION
Minor change that enables us to build without any issue.
Now we just have to use the command line : 
`npm run build`
and the resulting folder "dist" is all we need to share the website.