### PR TITLE
Design of events page

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint": "eslint --ext .js,.vue src test/unit/specs",
     "start": "node server.js",
     "postinstall": "npm run updatesemantic",
-    "updatesemantic" : "copyfiles -f src/config/css/theme.config node_modules/semantic-ui-less ; copyfiles -f src/config/css/site.variables ./node_modules/semantic-ui-less/themes/default/globals"
+    "updatesemantic" : "copyfiles -f src/config/css/site.variables ./node_modules/semantic-ui-less/themes/default/globals && copyfiles -f src/config/css/theme.config node_modules/semantic-ui-less"
   },
   "dependencies": {
     "moment": "^2.17.1",

--- a/src/config/css/semantic.less
+++ b/src/config/css/semantic.less
@@ -36,19 +36,19 @@
 & { @import "~semantic-ui-less/definitions/views/statistic"; }
 
 /* Modules */
-//& { @import "~semantic-ui-less/definitions/modules/accordion"; }
-//& { @import "~semantic-ui-less/definitions/modules/checkbox"; }
-//& { @import "~semantic-ui-less/definitions/modules/dimmer"; }
-//& { @import "~semantic-ui-less/definitions/modules/dropdown"; }
-//& { @import "~semantic-ui-less/definitions/modules/embed"; }
-//& { @import "~semantic-ui-less/definitions/modules/modal"; }
-//& { @import "~semantic-ui-less/definitions/modules/nag"; }
-//& { @import "~semantic-ui-less/definitions/modules/popup"; }
-//& { @import "~semantic-ui-less/definitions/modules/progress"; }
-//& { @import "~semantic-ui-less/definitions/modules/rating"; }
-//& { @import "~semantic-ui-less/definitions/modules/search"; }
-//& { @import "~semantic-ui-less/definitions/modules/shape"; }
-//& { @import "~semantic-ui-less/definitions/modules/sidebar"; }
-//& { @import "~semantic-ui-less/definitions/modules/sticky"; }
-//& { @import "~semantic-ui-less/definitions/modules/tab"; }
-//& { @import "~semantic-ui-less/definitions/modules/transition"; }
+& { @import "~semantic-ui-less/definitions/modules/accordion"; }
+& { @import "~semantic-ui-less/definitions/modules/checkbox"; }
+& { @import "~semantic-ui-less/definitions/modules/dimmer"; }
+& { @import "~semantic-ui-less/definitions/modules/dropdown"; }
+& { @import "~semantic-ui-less/definitions/modules/embed"; }
+& { @import "~semantic-ui-less/definitions/modules/modal"; }
+& { @import "~semantic-ui-less/definitions/modules/nag"; }
+& { @import "~semantic-ui-less/definitions/modules/popup"; }
+& { @import "~semantic-ui-less/definitions/modules/progress"; }
+& { @import "~semantic-ui-less/definitions/modules/rating"; }
+& { @import "~semantic-ui-less/definitions/modules/search"; }
+& { @import "~semantic-ui-less/definitions/modules/shape"; }
+& { @import "~semantic-ui-less/definitions/modules/sidebar"; }
+& { @import "~semantic-ui-less/definitions/modules/sticky"; }
+& { @import "~semantic-ui-less/definitions/modules/tab"; }
+& { @import "~semantic-ui-less/definitions/modules/transition"; }

--- a/src/config/css/site.variables
+++ b/src/config/css/site.variables
@@ -47,10 +47,10 @@
     Brand Colors
 --------------------*/
 
-@primaryColor        : @green;
+@primaryColor        : @olive;
 @secondaryColor      : @coral;
 
-@lightPrimaryColor   : @lightGreen;
+@lightPrimaryColor   : @lightOlive;
 @lightSecondaryColor : @lightCoral;
 
 /*--------------

--- a/src/config/css/theme.config
+++ b/src/config/css/theme.config
@@ -78,4 +78,19 @@
 
 @import "theme.less";
 
+
+
+
+/*******************************
+         Overrides
+*******************************/
+
+/*---------
+Message
+---------*/
+.ui.secondary.message {
+  background-color: lighten(@pageBackground,5);
+  color: @secondaryColor;
+}
+
 /* End Config */

--- a/src/routes/EventHome.vue
+++ b/src/routes/EventHome.vue
@@ -1,49 +1,106 @@
+<!--
+.ui.primary.message {
+  background-color: lighten(@pageBackground,5);
+  color: @primaryColor;
+}
+-->
+
 <template>
-  <div class="eventhome">
-    <!-- Button to add new event -->
-    <button  v-on:click="addEvent()">+</button>
-    <!-- For all events ... -->
-    <div v-for="(event, event_index) in events">
-      <h1> Event {{event.id}} </h1>
-      <div>
-        <input :disabled="!event.being_edited" v-model="event.title" placeholder="Title">
+  <div class="ui one column centered grid">
+
+    <div class="column">
+
+      <!-- Button to add new event -->
+      <div class="ui center aligned basic segment">
+        <button class="ui primary button" v-on:click="addEvent()">Créer un nouvel événement</button>
       </div>
-      <div>
-        <input :disabled="!event.being_edited" v-model="event.description" placeholder="Description">
-      </div>
-      <div>
-        <h4>Début</h4>
-        <Flatpickr :disabled="!event.being_edited" v-model="event.beginAt" :options="event.fpOptionsBeginDate"></Flatpickr>
-      </div>
-      <div>
-        <h4>Fin</h4>
-        <Flatpickr :disabled="!event.being_edited" v-model="event.endAt" :options="event.fpOptionsEndDate"></Flatpickr>
-      </div>
-      <div>
-        <h3> Produits </h3>
-        <!-- For each product of this event... -->
-        <div v-for="(event_product, index) in event.products">
-          <!-- Create a dropdown menu with value linked to the current product of the event -->
-          <select v-model="events[event_index].products[index]"  :disabled="!event.being_edited" >
-            <!-- Populate the options of this dropdown menu to be all available farm products -->
-            <option v-for="product in farm_products" v-bind:value="product">
-              {{product.name}}
-            </option>
-          </select>
-          <button v-if="event.being_edited" :id="index" v-on:click="removeProduct(event_index,index)">-</button>
+
+      <!-- For all events ... -->
+      <div class="ui equal width form" v-for="(event, event_index) in events">
+
+        <!-- frame surronding one event ... -->
+        <div class="ui container secondary message">
+
+          <!-- Number of the event ... -->
+          <div class="ui center aligned basic segment"> <h1> Event {{event.id}} </h1></div>
+
+          <!-- Title of the event ... -->
+          <div class="field">
+            <div class="ui labeled input">
+              <div class="ui olive inverted label" style="width:100px">Titre</div>
+              <input :disabled="!event.being_edited" v-model="event.title" placeholder="Title"></input>
+            </div>
+          </div>
+
+          <!-- Description of the event ... -->
+          <div class="field">
+            <div class="ui labeled input">
+              <div class="ui olive inverted label" style="width:100px">Description</div>
+              <textarea rows="2" :disabled="!event.being_edited" v-model="event.description" placeholder="Description"></textarea>
+            </div>
+          </div>
+
+          <!-- Beginning date ... -->
+          <div class="field">
+            <div class="ui labeled input">
+              <div class="ui olive inverted label" style="width:100px">Début</div>
+              <Flatpickr :disabled="!event.being_edited" v-model="event.beginAt" :options="event.fpOptionsBeginDate"></Flatpickr>
+            </div>
+          </div>
+
+          <!-- Ending date ... -->
+          <div class="field">
+            <div class="ui labeled input">
+              <div class="ui olive inverted label" style="width:100px">Fin</div>
+              <Flatpickr :disabled="!event.being_edited" v-model="event.endAt" :options="event.fpOptionsEndDate"></Flatpickr>
+            </div>
+          </div>
+
+          <!-- Products involved ... -->
+          <div class="field">
+            <div class="ui labeled two column input">
+
+              <div class="ui olive inverted label" style="width:100px">Produits</div>
+
+              <!-- For each product of this event... -->
+              <div v-for="(event_product, index) in event.products">
+                <!-- Create a dropdown menu with value linked to the current product of the event -->
+                <div class="column">
+                  <select v-model="events[event_index].products[index]"  :disabled="!event.being_edited" >
+                    <!-- Populate the options of this dropdown menu to be all available farm products -->
+                    <option v-for="product in farm_products" v-bind:value="product">
+                      {{product.name}}
+                    </option>
+                  </select>
+                  <button class="ui primary icon button" v-if="event.being_edited" :id="index" v-on:click="removeProduct(event_index,index)">
+                    <i class="remove icon">
+                  </button>
+                </div>
+              </div>
+
+              <button class="ui icon primary button" v-if="event.being_edited" :id="event_index" v-on:click="addProduct(event_index)">
+                <i class="add icon"></i>
+              </button>
+
+            </div>
+          </div>
+
+          <!-- Buttons to edit or delete the event ... -->
+          <div class="ui center aligned basic segment">
+            <button class="ui secondary button" v-on:click="editEvent(event_index)">{{event.being_edited ? "Enregistrer" : "Editer"}}</button>
+            <button class="ui secondary button" v-on:click="removeEvent(event_index)">Supprimer</button>
+          </div>
+
+
         </div>
+        <br>
       </div>
-      <button v-if="event.being_edited" :id="event_index" v-on:click="addProduct(event_index)">+</button>
-      <br> </br>
-      <button v-on:click="editEvent(event_index)">{{event.being_edited ? "Enregistrer" : "Editer"}}</button>
-      <button v-on:click="removeEvent(event_index)">Supprimer</button>
-      <br> </br>
+
+
     </div>
   </div>
+
 </template>
-
-
-
 
 <script>
   import Vue from 'vue'
@@ -93,6 +150,9 @@
 
   export default {
     /* global localStorage:true */
+    // mounted: function (){
+    //   this.$el.find('.dropdown').dropdown();
+    // },
     data () {
       // get user farm id
       this.$http.get(settings.urls.USER_INFO_URL, {
@@ -224,6 +284,3 @@
     }
   }
 </script>
-
-
-

--- a/src/routes/EventHome.vue
+++ b/src/routes/EventHome.vue
@@ -1,10 +1,3 @@
-<!--
-.ui.primary.message {
-  background-color: lighten(@pageBackground,5);
-  color: @primaryColor;
-}
--->
-
 <template>
   <div class="ui one column centered grid">
 
@@ -66,7 +59,7 @@
               <div v-for="(event_product, index) in event.products">
                 <!-- Create a dropdown menu with value linked to the current product of the event -->
                 <div class="column">
-                  <select v-model="events[event_index].products[index]"  :disabled="!event.being_edited" >
+                  <select class="ui search dropdown" v-model="events[event_index].products[index]"  :disabled="!event.being_edited" >
                     <!-- Populate the options of this dropdown menu to be all available farm products -->
                     <option v-for="product in farm_products" v-bind:value="product">
                       {{product.name}}
@@ -136,6 +129,7 @@
     }
   }
 
+
   // When an event comes from the server its products cant be bound using Vue-js' v-bind to
   // the full list of farm proposed products because they have different fields (different level of detail)
   // This function converts the "event" products into "farm_products" by matching and replacing them
@@ -147,12 +141,9 @@
     event.being_edited = false
   }
 
-
   export default {
     /* global localStorage:true */
-    // mounted: function (){
-    //   this.$el.find('.dropdown').dropdown();
-    // },
+
     data () {
       // get user farm id
       this.$http.get(settings.urls.USER_INFO_URL, {
@@ -191,6 +182,7 @@
         farm_products
       }
     },
+
     methods: {
       editEvent: function (event_index) {
         // If is being edited and is not a new event, continue with PUT, else if is new do a POST
@@ -277,10 +269,9 @@
             console.log(response)
           },
           function (error) {
-
           })
-
+        }
       }
-    }
+
   }
 </script>

--- a/src/routes/FarmHome.vue
+++ b/src/routes/FarmHome.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="ui three column centered grid">
+  <div class="ui two column centered grid">
     <div class="column">
       <div class="ui equal width form">
 

--- a/src/routes/Login.vue
+++ b/src/routes/Login.vue
@@ -1,29 +1,29 @@
 <template>
   <div class="ui center aligned one column grid">
     <div class="column">
-    <br>
-    <div class="ui left icon input">
-      <input type="text" name="email" placeholder="adresse e-mail" v-model="credentials.email">
-      <i class="user icon"></i>
-    </div>
-    <br>
-    <br>
-    <div class="ui left icon input">
-      <input type="password" name="password" placeholder="mot de passe" v-model="credentials.password">
-      <i class="lock icon"></i>
-    </div>
-    <br>
-    <br>
-    <button class="ui primary button" tabindex="0" v-on:click="submit">Connexion</button>
-    <br>
-    <br>
-    <div class="ui error compact message" v-if="attempted"> identifiants incorrects</div>
-    <br>
-    <div class="ui inverted primary basic button" v-on:click="sendPassword">
-      <div class="header">mot de passe oublié ?</div>
-      <div class="message" v-if="showLoginDetails">identifiants de test {{ loginDetails }}</div>
-    </div>
+      <br>
+      <div class="ui left icon input">
+        <input type="text" name="email" placeholder="adresse e-mail" v-model="credentials.email">
+        <i class="user icon"></i>
       </div>
+      <br>
+      <br>
+      <div class="ui left icon input">
+        <input type="password" name="password" placeholder="mot de passe" v-model="credentials.password">
+        <i class="lock icon"></i>
+      </div>
+      <br>
+      <br>
+      <button class="ui primary button" tabindex="0" v-on:click="submit">Connexion</button>
+      <br>
+      <br>
+      <div class="ui error compact message" v-if="attempted"> identifiants incorrects</div>
+      <br>
+      <div class="ui inverted primary basic button" v-on:click="sendPassword">
+        <div class="header">mot de passe oublié ?</div>
+        <div class="message" v-if="showLoginDetails">identifiants de test {{ loginDetails }}</div>
+      </div>
+    </div>
   </div>
 </template>
 


### PR DESCRIPTION
**Design update, using semantic-ui.**
Improves the appearance of the Events page, which consists in a succession of events : 
![2017-03-09](https://cloud.githubusercontent.com/assets/24297016/23753449/d42ec3c2-04d9-11e7-8243-6bcf15128671.png)
To do : ease the access to one particular event (-> accordion with the titles or list of the titles with routers?). Is the number of the event needed ?

The drop-down (to choose the products) still needs some improvements, for example allowing to search for the product you want by beginning to type its name.
![2017-03-09 3](https://cloud.githubusercontent.com/assets/24297016/23753456/dafa333a-04d9-11e7-92cb-6bb1d0da7b17.png)
